### PR TITLE
fix: use logical AND operator in sparse merkle tree calculate_two_roots

### DIFF
--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -178,7 +178,7 @@ where
             // and starting from each SUBSEQUENT iteration it is hashed with its sibling and the resulting hash
             // again stored in the container until the root is reached
             if sibling != T::default() {
-                if (i > 0) & (hash_path[i - 1] == T::default()) {
+                if (i > 0) && (hash_path[i - 1] == T::default()) {
                     root_without_leaf = hash_path[i];
                 }
 


### PR DESCRIPTION
**Why this matters:**
- **Correctness**: Bitwise `&` doesn't short-circuit and may produce unexpected results with boolean expressions
- **Performance**: Logical `&&` short-circuits, avoiding unnecessary evaluation of `hash_path[i - 1] == T::default()` when `i == 0`
- **Intent**: The code clearly intends to perform a logical AND operation between two boolean conditions

This is a critical fix that ensures the sparse merkle tree correctly handles the initialization of `root_without_leaf` during tree traversal.